### PR TITLE
Update Eigen requirement configuration

### DIFF
--- a/localizer/src/conanfile.py
+++ b/localizer/src/conanfile.py
@@ -17,6 +17,6 @@ class AppConan(ConanFile):
 
         # ---- conflict resolution: choose one Eigen for the whole graph ----
         # If the graph shows ORT wants 3.4.0, prefer:
-        self.requires("eigen/3.4.0", override=True)
+        self.requires("eigen/3.4.0")
         # If you decide to *force* a direct one instead (when you also require eigen directly):
         # self.requires("eigen/3.4.0", force=True)


### PR DESCRIPTION
## Summary
- declare Eigen as a normal requirement in the Conan recipe so it no longer overrides transitive selections

## Testing
- ⚠️ `conan install . --output-folder=build --build=missing -s build_type=Release -s compiler.cppstd=17 -c tools.cmake.cmaketoolchain:generator=Ninja` *(partially executed; cancelled due to extensive source builds triggered by the dependency graph)*

------
https://chatgpt.com/codex/tasks/task_e_690b1f059ec483229691d4bc51a0fd05