### PR TITLE
Fix ORT session path creation on non-Windows platforms

### DIFF
--- a/localizer/src/normalizers/NonlinearRegistrationEngine.cpp
+++ b/localizer/src/normalizers/NonlinearRegistrationEngine.cpp
@@ -5,10 +5,16 @@ NonlinearRegistrationEngine::NonlinearRegistrationEngine(const std::string& mode
     : env_(ORT_LOGGING_LEVEL_WARNING, "NonlinearRegistration"), session_(nullptr) {
     Ort::SessionOptions sessionOptions;
     sessionOptions.SetIntraOpNumThreads(1);
-    std::wstring w_modelPath = std::wstring(modelPath.begin(), modelPath.end());
+    const ORTCHAR_T* ortModelPath = nullptr;
+#ifdef _WIN32
+    std::wstring w_modelPath(modelPath.begin(), modelPath.end());
+    ortModelPath = w_modelPath.c_str();
+#else
+    ortModelPath = modelPath.c_str();
+#endif
 
     try {
-        session_ = new Ort::Session(env_, w_modelPath.c_str(), sessionOptions);
+        session_ = new Ort::Session(env_, ortModelPath, sessionOptions);
     } catch (const Ort::Exception& e) {
         std::cerr << "Error loading nonlinear registration model: " << e.what() << std::endl;
         throw std::runtime_error("Failed to load nonlinear registration model.");

--- a/localizer/src/normalizers/RigidRegistrationEngine.cpp
+++ b/localizer/src/normalizers/RigidRegistrationEngine.cpp
@@ -42,10 +42,16 @@ RigidRegistrationEngine::RigidRegistrationEngine(const std::string& modelPath)
     : env_(ORT_LOGGING_LEVEL_WARNING, "RigidRegistration"), session_(nullptr) {
     Ort::SessionOptions sessionOptions;
     sessionOptions.SetIntraOpNumThreads(1);
-    std::wstring w_modelPath = std::wstring(modelPath.begin(), modelPath.end());
+    const ORTCHAR_T* ortModelPath = nullptr;
+#ifdef _WIN32
+    std::wstring w_modelPath(modelPath.begin(), modelPath.end());
+    ortModelPath = w_modelPath.c_str();
+#else
+    ortModelPath = modelPath.c_str();
+#endif
 
     try {
-        session_ = new Ort::Session(env_, w_modelPath.c_str(), sessionOptions);
+        session_ = new Ort::Session(env_, ortModelPath, sessionOptions);
     } catch (const Ort::Exception& e) {
         std::cerr << "Error loading rigid registration model: " << e.what() << std::endl;
         throw std::runtime_error("Failed to load rigid registration model.");


### PR DESCRIPTION
## Summary
- ensure ONNX Runtime session creation uses the correct character type on each platform for rigid registration
- reuse the same platform-aware handling for the nonlinear registration engine

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690b28726e2883229c881d745c82f20c