### PR TITLE
Normalize ITK index initialization across helpers

### DIFF
--- a/localizer/src/utils/common.cpp
+++ b/localizer/src/utils/common.cpp
@@ -58,7 +58,8 @@ double CalculateMeanInMask(ImageType::Pointer image, ImageType::Pointer mask) {
 ImageType::Pointer CreateImageFromVector(const std::vector<float>& imageData,
                                          ImageType::SizeType size) {
   ImageType::Pointer image = ImageType::New();
-  ImageType::IndexType start = {{0, 0, 0}};
+  ImageType::IndexType start;
+  start.Fill(0);
   ImageType::RegionType region;
   region.SetSize(size);
   region.SetIndex(start);
@@ -70,7 +71,10 @@ ImageType::Pointer CreateImageFromVector(const std::vector<float>& imageData,
   for (size_t x = 0; x < size[0]; ++x) {
     for (size_t y = 0; y < size[1]; ++y) {
       for (size_t z = 0; z < size[2]; ++z) {
-        ImageType::IndexType index = {{x, y, z}};
+        ImageType::IndexType index;
+        index[0] = static_cast<ImageType::IndexValueType>(x);
+        index[1] = static_cast<ImageType::IndexValueType>(y);
+        index[2] = static_cast<ImageType::IndexValueType>(z);
         size_t vectorIndex = x * size[1] * size[2] + y * size[2] + z;
         image->SetPixel(index, imageData[vectorIndex]);
       }
@@ -129,7 +133,10 @@ void ExtractImageData(ImageType::Pointer image, std::vector<float>& imageData) {
   for (size_t x = 0; x < size[0]; ++x) {
     for (size_t y = 0; y < size[1]; ++y) {
       for (size_t z = 0; z < size[2]; ++z) {
-        ImageType::IndexType index = {{x, y, z}};
+        ImageType::IndexType index;
+        index[0] = static_cast<ImageType::IndexValueType>(x);
+        index[1] = static_cast<ImageType::IndexValueType>(y);
+        index[2] = static_cast<ImageType::IndexValueType>(z);
         float pixelValue = image->GetPixel(index);
         imageData[x * size[1] * size[2] + y * size[2] + z] = pixelValue;
       }


### PR DESCRIPTION
## Summary
- replace the remaining double-brace ITK index initialization with Fill to avoid narrowing diagnostics
- verified that other voxel loops already cast coordinates before storing them in IndexType instances

## Testing
- cmake -S . -B build *(fails: missing Slicer package configuration)*

------
https://chatgpt.com/codex/tasks/task_e_690b49257c408322bbbc093d7c0c8f60