### PR TITLE
Fix ONNX path conversion for non-Windows builds

### DIFF
--- a/localizer/src/core/common/OnnxPath.h
+++ b/localizer/src/core/common/OnnxPath.h
@@ -49,15 +49,15 @@ inline std::string stageModelPathIfNeeded(const std::string& path) {
 inline std::basic_string<ORTCHAR_T> makeOrtPath(const std::string& path) {
     const std::string preparedPath = detail::stageModelPathIfNeeded(path);
 
-    if constexpr (std::is_same_v<ORTCHAR_T, wchar_t>) {
 #ifdef _WIN32
+    if constexpr (std::is_same_v<ORTCHAR_T, wchar_t>) {
         return Common::path::utf8ToWide(preparedPath);
-#else
-        return std::wstring(preparedPath.begin(), preparedPath.end());
-#endif
     } else {
         return preparedPath;
     }
+#else
+    return preparedPath;
+#endif
 }
 
 }  // namespace Common::onnx


### PR DESCRIPTION
### Motivation
- A recent change added wide-char conversion in `makeOrtPath` which on macOS/Linux produced a `basic_string<wchar_t>` -> `basic_string<char>` return-type mismatch and broke compilation.

### Description
- Update `localizer/src/core/common/OnnxPath.h` so `makeOrtPath` does `Common::path::utf8ToWide(preparedPath)` only inside the Windows (`_WIN32`) branch when `ORTCHAR_T` is `wchar_t`, and return `preparedPath` directly on non-Windows platforms to preserve correct return types.

### Testing
- Attempted to run CMake configure and build in `localizer/src` to validate the change, but the run stopped because the environment is missing `ITK` (`ITKConfig.cmake`) and a LFS pointer file (`localizer/Testing/ED01_PET.nii`), so a full build could not be completed. No automated unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d208c71588322a33de4c39848a6df)