### PR TITLE
Add `rigid` subcommand for rigid-only alignment

### DIFF
--- a/localizer/src/CMakeLists.txt
+++ b/localizer/src/CMakeLists.txt
@@ -180,6 +180,8 @@ target_sources(DCCCcore PRIVATE
     spatialNormalizations/standard/NormalizeCLI.cpp
     spatialNormalizations/adni/AdniPetCoreCLI.h
     spatialNormalizations/adni/AdniPetCoreCLI.cpp
+    spatialNormalizations/rigid/RigidCLI.h
+    spatialNormalizations/rigid/RigidCLI.cpp
 )
 
 # Link libraries

--- a/localizer/src/core/common/NormalizationContracts.h
+++ b/localizer/src/core/common/NormalizationContracts.h
@@ -8,6 +8,7 @@ namespace Pipeline {
 struct SpatialNormalizationOptions {
     bool useIterativeRigid = false;
     bool useManualFOV = false;
+    bool rigidOnly = false;
     bool enableDebugOutput = false;
     std::string debugOutputBasePath;
     bool enableAdniPetCore = false;

--- a/localizer/src/core/services/SpatialNormalizationService.cpp
+++ b/localizer/src/core/services/SpatialNormalizationService.cpp
@@ -37,15 +37,19 @@ SpatialNormalizationOutput SpatialNormalizationService::normalize(const SpatialN
                 request.options.maxIterations,
                 request.options.convergenceThreshold);
             output.rigidAlignedImage = normResult.rigidAlignedImage;
-            output.spatiallyNormalizedImage = normResult.spatiallyNormalizedImage;
+            output.spatiallyNormalizedImage = request.options.rigidOnly
+                                                 ? normResult.rigidAlignedImage
+                                                 : normResult.spatiallyNormalizedImage;
         } else {
             auto normResult = normalizer->normalizeWithIntermediateResults(inputImage);
             output.rigidAlignedImage = normResult.rigidAlignedImage;
-            output.spatiallyNormalizedImage = normResult.spatiallyNormalizedImage;
+            output.spatiallyNormalizedImage = request.options.rigidOnly
+                                                 ? normResult.rigidAlignedImage
+                                                 : normResult.spatiallyNormalizedImage;
         }
     }
 
-    if (request.options.enableAdniPetCore) {
+    if (request.options.enableAdniPetCore && !request.options.rigidOnly) {
         output.spatiallyNormalizedImage = prepareAdniPetCoreImage(
             output.rigidAlignedImage,
             output.spatiallyNormalizedImage);
@@ -90,4 +94,3 @@ ImageType::Pointer SpatialNormalizationService::prepareAdniPetCoreImage(ImageTyp
 }
 
 } // namespace Pipeline
-

--- a/localizer/src/spatialNormalizations/ModuleCatalog.cpp
+++ b/localizer/src/spatialNormalizations/ModuleCatalog.cpp
@@ -1,6 +1,7 @@
 #include "ModuleCatalog.h"
 #include "standard/NormalizeCLI.h"
 #include "adni/AdniPetCoreCLI.h"
+#include "rigid/RigidCLI.h"
 
 namespace Pipeline::SpatialNormalization {
 
@@ -8,10 +9,10 @@ std::vector<SpatialNormalizationCLIPtr> buildCLIModules() {
     std::vector<SpatialNormalizationCLIPtr> modules;
     modules.push_back(Standard::createCLI());
     modules.push_back(Adni::createCLI());
+    modules.push_back(Rigid::createCLI());
     return modules;
 }
 
 } // namespace Pipeline::SpatialNormalization
-
 
 

--- a/localizer/src/spatialNormalizations/rigid/RigidCLI.cpp
+++ b/localizer/src/spatialNormalizations/rigid/RigidCLI.cpp
@@ -1,0 +1,80 @@
+#include "RigidCLI.h"
+#include "../CLIOptions.h"
+#include "../../core/common/Filesystem.h"
+#include "../../core/di/Bootstrap.h"
+#include "../../core/services/IFileService.h"
+#include "../../core/services/ISpatialNormalizationService.h"
+#include <exception>
+#include <iostream>
+
+namespace Pipeline::SpatialNormalization::Rigid {
+
+namespace {
+
+class RigidCLI final : public ISpatialNormalizationCLI {
+public:
+    std::string getSubcommandName() const override {
+        return "rigid";
+    }
+
+    std::string getDescription() const override {
+        return "Run rigid-only alignment and update affine matrix without resampling";
+    }
+
+    void configureArguments(argparse::ArgumentParser& parser) override {
+        addBaseArguments(parser);
+    }
+
+    int execute(const argparse::ArgumentParser& parser, const std::string& fullCommand) override {
+        NormalizeCommandOptions options;
+        options.inputPath = parser.get<std::string>("--input");
+        options.outputPath = parser.get<std::string>("--output");
+        options.configPath = parser.get<std::string>("--config");
+        options.enableDebugOutput = parser.get<bool>("--debug");
+
+        if (!Common::fs::ensureParentDirectory(options.outputPath)) {
+            std::cerr << "[rigid] Failed to prepare output directory: " << options.outputPath << std::endl;
+            return EXIT_FAILURE;
+        }
+
+        if (options.enableDebugOutput) {
+            setupDebugOutput(options);
+        }
+
+        std::cout << "[rigid] Starting processing: " << fullCommand << std::endl;
+
+        BootstrapOptions bootstrapOptions;
+        bootstrapOptions.configPath = options.configPath;
+        bootstrapOptions.enableConfigDebug = options.enableDebugOutput;
+        bootstrapOptions.logTag = "rigid";
+
+        auto container = Pipeline::buildCoreContainer(bootstrapOptions);
+        auto spatialService = container->resolve<ISpatialNormalizationService>();
+        auto fileService = container->resolve<IFileService>();
+
+        SpatialNormalizationRequest request;
+        request.inputPath = options.inputPath;
+        request.skip = false;
+        request.options.rigidOnly = true;
+        request.options.enableDebugOutput = options.enableDebugOutput;
+        request.options.debugOutputBasePath = options.debugOutputBasePath;
+
+        try {
+            auto output = spatialService->normalize(request);
+            fileService->saveNormalizedImage({output.spatiallyNormalizedImage, options.outputPath});
+            std::cout << "[rigid] Rigid alignment complete. Output saved to " << options.outputPath << std::endl;
+            return EXIT_SUCCESS;
+        } catch (const std::exception& ex) {
+            std::cerr << "[rigid] Processing failed: " << ex.what() << std::endl;
+            return EXIT_FAILURE;
+        }
+    }
+};
+
+} // namespace
+
+SpatialNormalizationCLIPtr createCLI() {
+    return std::make_shared<RigidCLI>();
+}
+
+} // namespace Pipeline::SpatialNormalization::Rigid

--- a/localizer/src/spatialNormalizations/rigid/RigidCLI.h
+++ b/localizer/src/spatialNormalizations/rigid/RigidCLI.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "../../core/interfaces/ISpatialNormalizationCLI.h"
+
+namespace Pipeline::SpatialNormalization::Rigid {
+
+SpatialNormalizationCLIPtr createCLI();
+
+} // namespace Pipeline::SpatialNormalization::Rigid

--- a/localizer/src/tests/test_quick_cli.py
+++ b/localizer/src/tests/test_quick_cli.py
@@ -19,6 +19,7 @@ TEST_CASES: List[Dict[str, Any]] = [
     {"id": "refactor_adad_help", "args": ["adad", "--help"], "expected_failure": False},
     {"id": "normalize_help", "args": ["normalize", "--help"], "expected_failure": False},
     {"id": "adni_pet_core_help", "args": ["adni-pet-core", "--help"], "expected_failure": False},
+    {"id": "rigid_help", "args": ["rigid", "--help"], "expected_failure": False},
     {
         "id": "refactor_centiloid_basic",
         "args": ["centiloid", "--input", "{input}", "--output", "{output}"],


### PR DESCRIPTION
### Motivation
- Provide a simple subcommand that performs rigid-only alignment by updating the image affine without performing resampling, intensity scaling, or nonlinear warping.
- Allow callers to opt into a lightweight flow useful for cases that only need affine correction (simpler than `adni-pet-core`).

### Description
- Added a new spatial normalization CLI module `rigid` with `localizer/src/spatialNormalizations/rigid/RigidCLI.h` and `.../RigidCLI.cpp` that accepts base arguments and triggers a rigid-only request.
- Introduced a `rigidOnly` flag in `localizer/src/core/common/NormalizationContracts.h` to represent the rigid-only mode in the normalization options.
- Updated `localizer/src/core/services/SpatialNormalizationService.cpp` to return the rigid-aligned image as the final output when `rigidOnly` is set and to skip ADNI-style postprocessing in that case.
- Registered the new module in `localizer/src/spatialNormalizations/ModuleCatalog.cpp` and added the new source files to `localizer/src/CMakeLists.txt`; also added a quick CLI test case in `localizer/src/tests/test_quick_cli.py` for `rigid --help`.

### Testing
- Ran the quick CLI help test case with `pytest -q localizer/src/tests/test_quick_cli.py -k rigid_help`, which errored because the test environment expected the `DCCCcore` executable at `localizer/src/install/bin/DCCCcore` and it was not present, so the test could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dae57784c8322b38a4c916939a7f0)