### PR TITLE
Add rigid debug timing and release DCCCcore 4.2.4

### DIFF
--- a/docs/rigid-iterative-ct-benchmark.md
+++ b/docs/rigid-iterative-ct-benchmark.md
@@ -124,3 +124,23 @@ Component split behavior check:
 ## Notes
 
 Further speed or memory reductions would require changing the iterative model input or the first rigid preprocessing pass so that very high-resolution images are downsampled before percentile clipping and smoothing. The low-resolution-cache experiment shows that this is a behavioral change and must be validated against affine accuracy before acceptance.
+
+## Follow-up: Large CTA Output Compression
+
+Date: 2026-07-02
+
+Later field testing found another major source of apparent rigid slowness:
+large CTA inputs can produce very large output images, and writing the output
+as `.nii.gz` can spend substantial wall time in gzip compression. In that
+case the slow part is not rigid alignment itself, but compressed NIfTI output
+I/O.
+
+When benchmarking rigid performance on high-resolution CT/CTA cases:
+
+- Use an uncompressed `.nii` output path to isolate rigid compute time.
+- Measure `.nii.gz` output separately if compressed-output wall time matters
+  for deployment.
+- Treat output extension as part of the benchmark configuration, because
+  `.nii` and `.nii.gz` can differ significantly for large volumes.
+- Be careful with `--debug`: debug mode writes multiple intermediate NIfTI
+  files, so output I/O can dominate the timing on large CTA cases.

--- a/localizer/src/CMakeLists.txt
+++ b/localizer/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 # CMakeList.txt: DCCCcore Refactored Version
 cmake_minimum_required(VERSION 3.21)
 
-project(DCCCcore VERSION 4.2.3)
-set(DCCCCORE_VERSION_SUFFIX "-alpha")
+project(DCCCcore VERSION 4.2.4)
+set(DCCCCORE_VERSION_SUFFIX "")
 set(DCCCCORE_SOFTWARE_VERSION "${PROJECT_VERSION}${DCCCCORE_VERSION_SUFFIX}")
 
 # Set C++ standard
@@ -72,6 +72,8 @@ target_sources(DCCCcore PRIVATE
 # Add utility sources
 target_sources(DCCCcore PRIVATE
     core/common/Common.h
+    core/common/DebugReporter.h
+    core/common/DebugReporter.cpp
     core/common/ImageTypes.h
     core/common/NiftiTypes.h
     core/common/NiftiIO.h

--- a/localizer/src/conanfile.py
+++ b/localizer/src/conanfile.py
@@ -4,7 +4,7 @@ from conan import ConanFile
 
 class AppConan(ConanFile):
     name = "DCCCcore"
-    version = "4.2.3-alpha"
+    version = "4.2.4"
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain"
 

--- a/localizer/src/core/common/DebugReporter.cpp
+++ b/localizer/src/core/common/DebugReporter.cpp
@@ -1,0 +1,101 @@
+#include "DebugReporter.h"
+
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <utility>
+
+namespace Common::debug {
+
+ScopedStage::ScopedStage()
+    : reporter_(nullptr), startedAt_(), active_(false) {}
+
+ScopedStage::ScopedStage(DebugReporter* reporter, std::string label, std::string details)
+    : reporter_(reporter),
+      label_(std::move(label)),
+      startedAt_(DebugReporter::Clock::now()),
+      active_(reporter_ != nullptr) {
+    if (active_) {
+        reporter_->beginStage(label_, details);
+    }
+}
+
+ScopedStage::ScopedStage(ScopedStage&& other) noexcept
+    : reporter_(other.reporter_),
+      label_(std::move(other.label_)),
+      startedAt_(other.startedAt_),
+      active_(other.active_) {
+    other.reporter_ = nullptr;
+    other.active_ = false;
+}
+
+ScopedStage& ScopedStage::operator=(ScopedStage&& other) noexcept {
+    if (this != &other) {
+        if (active_ && reporter_) {
+            reporter_->endStage(label_, startedAt_);
+        }
+        reporter_ = other.reporter_;
+        label_ = std::move(other.label_);
+        startedAt_ = other.startedAt_;
+        active_ = other.active_;
+        other.reporter_ = nullptr;
+        other.active_ = false;
+    }
+    return *this;
+}
+
+ScopedStage::~ScopedStage() {
+    if (active_ && reporter_) {
+        reporter_->endStage(label_, startedAt_);
+    }
+}
+
+DebugReporter::DebugReporter(std::string component, std::ostream& output)
+    : component_(std::move(component)),
+      startedAt_(Clock::now()),
+      output_(&output) {
+    event("debug_start");
+}
+
+DebugReporter::DebugReporter(std::string component)
+    : DebugReporter(std::move(component), std::cout) {}
+
+void DebugReporter::event(const std::string& label, const std::string& details) const {
+    write(label, details);
+}
+
+ScopedStage DebugReporter::scope(const std::string& label, const std::string& details) {
+    return ScopedStage(this, label, details);
+}
+
+void DebugReporter::beginStage(const std::string& label, const std::string& details) const {
+    write(label + ".begin", details);
+}
+
+void DebugReporter::endStage(const std::string& label, Clock::time_point startedAt) const {
+    write(label + ".end",
+          "duration_ms=" + formatMilliseconds(elapsedMilliseconds(startedAt)));
+}
+
+double DebugReporter::elapsedMilliseconds(Clock::time_point at) const {
+    return std::chrono::duration<double, std::milli>(Clock::now() - at).count();
+}
+
+std::string DebugReporter::formatMilliseconds(double value) {
+    std::ostringstream stream;
+    stream << std::fixed << std::setprecision(3) << value;
+    return stream.str();
+}
+
+void DebugReporter::write(const std::string& label, const std::string& details) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    *output_ << "[debug][" << component_ << "][+"
+             << formatMilliseconds(elapsedMilliseconds(startedAt_))
+             << " ms] " << label;
+    if (!details.empty()) {
+        *output_ << " " << details;
+    }
+    *output_ << std::endl;
+}
+
+}  // namespace Common::debug

--- a/localizer/src/core/common/DebugReporter.h
+++ b/localizer/src/core/common/DebugReporter.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <chrono>
+#include <iosfwd>
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace Common::debug {
+
+class DebugReporter;
+
+class ScopedStage {
+public:
+    ScopedStage();
+    ScopedStage(DebugReporter* reporter, std::string label, std::string details = "");
+    ScopedStage(const ScopedStage&) = delete;
+    ScopedStage& operator=(const ScopedStage&) = delete;
+    ScopedStage(ScopedStage&& other) noexcept;
+    ScopedStage& operator=(ScopedStage&& other) noexcept;
+    ~ScopedStage();
+
+private:
+    DebugReporter* reporter_;
+    std::string label_;
+    std::chrono::steady_clock::time_point startedAt_;
+    bool active_;
+};
+
+class DebugReporter {
+public:
+    explicit DebugReporter(std::string component, std::ostream& output);
+    explicit DebugReporter(std::string component);
+
+    void event(const std::string& label, const std::string& details = "") const;
+    ScopedStage scope(const std::string& label, const std::string& details = "");
+
+private:
+    friend class ScopedStage;
+
+    using Clock = std::chrono::steady_clock;
+
+    void beginStage(const std::string& label, const std::string& details) const;
+    void endStage(const std::string& label, Clock::time_point startedAt) const;
+    double elapsedMilliseconds(Clock::time_point at) const;
+    static std::string formatMilliseconds(double value);
+    void write(const std::string& label, const std::string& details) const;
+
+    std::string component_;
+    Clock::time_point startedAt_;
+    std::ostream* output_;
+    mutable std::mutex mutex_;
+};
+
+using DebugReporterPtr = std::shared_ptr<DebugReporter>;
+
+}  // namespace Common::debug

--- a/localizer/src/core/common/NormalizationContracts.h
+++ b/localizer/src/core/common/NormalizationContracts.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "DebugReporter.h"
 #include "ImageTypes.h"
 #include <string>
 
@@ -14,6 +15,7 @@ struct SpatialNormalizationOptions {
     bool enableAdniPetCore = false;
     int maxIterations = 5;
     float convergenceThreshold = 2.0f;
+    Common::debug::DebugReporterPtr debugReporter;
 };
 
 struct SpatialNormalizationRequest {

--- a/localizer/src/core/config/Version.h
+++ b/localizer/src/core/config/Version.h
@@ -1,4 +1,4 @@
 #pragma once
 #include <string>
 
-const std::string SOFTWARE_VERSION = "4.2.3-alpha";
+const std::string SOFTWARE_VERSION = "4.2.4";

--- a/localizer/src/core/normalizers/RigidAlignmentNormalizer.cpp
+++ b/localizer/src/core/normalizers/RigidAlignmentNormalizer.cpp
@@ -4,33 +4,80 @@
 #include "../preprocessing/ImagePreprocessor.h"
 
 #include <cmath>
+#include <sstream>
 #include <stdexcept>
+#include <utility>
+
+namespace {
+
+std::string describeImage(ImageType::Pointer image) {
+    if (!image) {
+        return "image=null";
+    }
+
+    const auto size = image->GetLargestPossibleRegion().GetSize();
+    const auto spacing = image->GetSpacing();
+    std::ostringstream stream;
+    stream << "size=" << size[0] << "x" << size[1] << "x" << size[2]
+           << " spacing=" << spacing[0] << "x" << spacing[1] << "x"
+           << spacing[2];
+    return stream.str();
+}
+
+}  // namespace
 
 RigidAlignmentNormalizer::RigidAlignmentNormalizer(ConfigurationPtr config)
-    : config_(config) {
+    : RigidAlignmentNormalizer(config, nullptr) {}
+
+RigidAlignmentNormalizer::RigidAlignmentNormalizer(
+    ConfigurationPtr config, Common::debug::DebugReporterPtr debugReporter)
+    : config_(config), debugReporter_(std::move(debugReporter)) {
     if (!config_) {
         throw std::invalid_argument("RigidAlignmentNormalizer requires configuration");
     }
 
-    rigidEngine_ =
-        std::make_unique<RigidRegistrationEngine>(config_->getModelPath("rigid"));
-    paddedTemplate_ = Common::nifti::loadImage(config_->getTemplatePath("padded"));
+    {
+        const std::string modelPath = config_->getModelPath("rigid");
+        auto scope = debugReporter_ ? debugReporter_->scope("load_rigid_model", modelPath)
+                                    : Common::debug::ScopedStage{};
+        rigidEngine_ =
+            std::make_unique<RigidRegistrationEngine>(modelPath, debugReporter_);
+    }
+    {
+        const std::string templatePath = config_->getTemplatePath("padded");
+        auto scope = debugReporter_ ? debugReporter_->scope("load_padded_template", templatePath)
+                                    : Common::debug::ScopedStage{};
+        paddedTemplate_ = Common::nifti::loadImage(templatePath);
+        if (debugReporter_) {
+            debugReporter_->event("padded_template", describeImage(paddedTemplate_));
+        }
+    }
 }
 
 ImageType::Pointer RigidAlignmentNormalizer::align(ImageType::Pointer inputImage) {
-    ImageType::Pointer rigidImage = performAlignment(inputImage);
+    auto scope = debugReporter_ ? debugReporter_->scope("rigid.align", describeImage(inputImage))
+                                : Common::debug::ScopedStage{};
+    ImageType::Pointer rigidImage = performAlignment(inputImage, false, "rigid.single");
     saveDebugImage(rigidImage, "rigid");
     return rigidImage;
 }
 
 ImageType::Pointer RigidAlignmentNormalizer::alignIterative(
     ImageType::Pointer inputImage, int maxIter, float threshold) {
-    ImageType::Pointer currentImage = performAlignment(inputImage, false);
+    auto scope = debugReporter_
+                     ? debugReporter_->scope("rigid.align_iterative",
+                                             describeImage(inputImage) +
+                                                 " max_iter=" + std::to_string(maxIter) +
+                                                 " threshold=" + std::to_string(threshold))
+                     : Common::debug::ScopedStage{};
+    ImageType::Pointer currentImage =
+        performAlignment(inputImage, false, "rigid.iteration0");
     saveDebugImage(currentImage, "rigid0");
     ImageType::PointType lastOrigin = currentImage->GetOrigin();
 
     for (int i = 0; i < maxIter; ++i) {
-        currentImage = performAlignment(currentImage, true);
+        const std::string stageLabel = "rigid.iteration" + std::to_string(i + 1);
+        currentImage = performAlignment(currentImage, true, stageLabel);
         saveDebugImage(currentImage, "rigid" + std::to_string(i + 1));
 
         float originShift = 0;
@@ -39,8 +86,16 @@ ImageType::Pointer RigidAlignmentNormalizer::alignIterative(
                 std::pow(currentImage->GetOrigin()[j] - lastOrigin[j], 2);
         }
         originShift = std::sqrt(originShift);
+        if (debugReporter_) {
+            debugReporter_->event(stageLabel + ".origin_shift",
+                                  "mm=" + std::to_string(originShift));
+        }
 
         if (originShift < threshold) {
+            if (debugReporter_) {
+                debugReporter_->event(stageLabel + ".converged",
+                                      "threshold=" + std::to_string(threshold));
+            }
             break;
         }
         lastOrigin = currentImage->GetOrigin();
@@ -50,44 +105,71 @@ ImageType::Pointer RigidAlignmentNormalizer::alignIterative(
 }
 
 RigidAlignmentNormalizer::AlignmentEstimate RigidAlignmentNormalizer::estimate(
-    ImageType::Pointer inputImage, bool resampleFirst) {
+    ImageType::Pointer inputImage, bool resampleFirst, const std::string& stageLabel) {
+    auto scope = debugReporter_ ? debugReporter_->scope(stageLabel + ".estimate")
+                                : Common::debug::ScopedStage{};
     ImageType::Pointer processedImage = inputImage;
 
     if (resampleFirst) {
+        auto resampleScope =
+            debugReporter_
+                ? debugReporter_->scope(stageLabel + ".resample_to_padded_template",
+                                        describeImage(processedImage))
+                : Common::debug::ScopedStage{};
         processedImage = Common::image::resampleToMatch(paddedTemplate_, processedImage);
+        if (debugReporter_) {
+            debugReporter_->event(stageLabel + ".resampled_image",
+                                  describeImage(processedImage));
+        }
     }
 
-    processedImage = ImagePreprocessor::preprocessForRigid(processedImage);
+    processedImage =
+        ImagePreprocessor::preprocessForRigid(
+            processedImage, debugReporter_.get(), stageLabel + ".preprocess");
     saveDebugImage(processedImage, "rigid_preprocessed");
 
     std::vector<float> imageData;
-    Common::image::extractImageData(processedImage, imageData);
+    {
+        auto extractScope = debugReporter_
+                                ? debugReporter_->scope(stageLabel + ".extract_tensor_data",
+                                                        describeImage(processedImage))
+                                : Common::debug::ScopedStage{};
+        Common::image::extractImageData(processedImage, imageData);
+    }
 
     auto orientation = rigidEngine_->predict(imageData, {1, 1, 64, 64, 64});
     return AlignmentEstimate{processedImage, orientation};
 }
 
 void RigidAlignmentNormalizer::apply(ImageType::Pointer targetImage,
-                                     const AlignmentEstimate& estimate) {
+                                     const AlignmentEstimate& estimate,
+                                     const std::string& stageLabel) {
     if (!targetImage) {
         return;
     }
 
-    auto newOriginAndDirection = rigidEngine_->getNewOriginAndDirection(
-        estimate.preprocessedImage,
-        targetImage,
-        estimate.orientation.at("ac"),
-        estimate.orientation.at("pa"),
-        estimate.orientation.at("is"));
+    auto scope = debugReporter_ ? debugReporter_->scope(stageLabel + ".apply_transform")
+                                : Common::debug::ScopedStage{};
+    auto newOriginAndDirection =
+        rigidEngine_->getNewOriginAndDirection(estimate.preprocessedImage,
+                                               targetImage,
+                                               estimate.orientation.at("ac"),
+                                               estimate.orientation.at("pa"),
+                                               estimate.orientation.at("is"));
 
     targetImage->SetOrigin(std::get<0>(newOriginAndDirection));
     targetImage->SetDirection(std::get<1>(newOriginAndDirection));
 }
 
 ImageType::Pointer RigidAlignmentNormalizer::performAlignment(
-    ImageType::Pointer inputImage, bool resampleFirst) {
-    auto alignmentEstimate = estimate(inputImage, resampleFirst);
-    apply(inputImage, alignmentEstimate);
+    ImageType::Pointer inputImage, bool resampleFirst, const std::string& stageLabel) {
+    auto scope = debugReporter_ ? debugReporter_->scope(stageLabel + ".perform_alignment",
+                                                        "resample_first=" +
+                                                            std::string(resampleFirst ? "true"
+                                                                                      : "false"))
+                                : Common::debug::ScopedStage{};
+    auto alignmentEstimate = estimate(inputImage, resampleFirst, stageLabel);
+    apply(inputImage, alignmentEstimate, stageLabel);
     return inputImage;
 }
 
@@ -101,5 +183,8 @@ void RigidAlignmentNormalizer::saveDebugImage(ImageType::Pointer image,
     if (!debugMode_ || debugBasePath_.empty()) {
         return;
     }
-    Common::nifti::saveImage(image, debugBasePath_ + "_" + suffix + ".nii");
+    const std::string outputPath = debugBasePath_ + "_" + suffix + ".nii";
+    auto scope = debugReporter_ ? debugReporter_->scope("save_debug_image", outputPath)
+                                : Common::debug::ScopedStage{};
+    Common::nifti::saveImage(image, outputPath);
 }

--- a/localizer/src/core/normalizers/RigidAlignmentNormalizer.h
+++ b/localizer/src/core/normalizers/RigidAlignmentNormalizer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../common/DebugReporter.h"
 #include "../common/ImageTypes.h"
 #include "../interfaces/IConfiguration.h"
 #include "RigidRegistrationEngine.h"
@@ -12,6 +13,8 @@
 class RigidAlignmentNormalizer {
 public:
     explicit RigidAlignmentNormalizer(ConfigurationPtr config);
+    RigidAlignmentNormalizer(ConfigurationPtr config,
+                             Common::debug::DebugReporterPtr debugReporter);
 
     ImageType::Pointer align(ImageType::Pointer inputImage);
     ImageType::Pointer alignIterative(ImageType::Pointer inputImage,
@@ -31,9 +34,16 @@ private:
     ImageType::Pointer paddedTemplate_;
     bool debugMode_ = false;
     std::string debugBasePath_;
+    Common::debug::DebugReporterPtr debugReporter_;
 
-    AlignmentEstimate estimate(ImageType::Pointer inputImage, bool resampleFirst = false);
-    void apply(ImageType::Pointer targetImage, const AlignmentEstimate& estimate);
-    ImageType::Pointer performAlignment(ImageType::Pointer inputImage, bool resampleFirst = false);
+    AlignmentEstimate estimate(ImageType::Pointer inputImage,
+                               bool resampleFirst = false,
+                               const std::string& stageLabel = "rigid");
+    void apply(ImageType::Pointer targetImage,
+               const AlignmentEstimate& estimate,
+               const std::string& stageLabel = "rigid");
+    ImageType::Pointer performAlignment(ImageType::Pointer inputImage,
+                                        bool resampleFirst = false,
+                                        const std::string& stageLabel = "rigid");
     void saveDebugImage(ImageType::Pointer image, const std::string& suffix);
 };

--- a/localizer/src/core/normalizers/RigidRegistrationEngine.cpp
+++ b/localizer/src/core/normalizers/RigidRegistrationEngine.cpp
@@ -1,6 +1,7 @@
 #include "RigidRegistrationEngine.h"
 #include <vnl/vnl_vector.h>
 #include <iostream>
+#include <utility>
 #include "itkCrossHelper.h"
 #include "../common/OnnxPath.h"
 
@@ -40,12 +41,20 @@ namespace {
 }
 
 RigidRegistrationEngine::RigidRegistrationEngine(const std::string& modelPath)
-    : env_(ORT_LOGGING_LEVEL_WARNING, "RigidRegistration"), session_(nullptr) {
+    : RigidRegistrationEngine(modelPath, nullptr) {}
+
+RigidRegistrationEngine::RigidRegistrationEngine(
+    const std::string& modelPath, Common::debug::DebugReporterPtr debugReporter)
+    : env_(ORT_LOGGING_LEVEL_WARNING, "RigidRegistration"),
+      session_(nullptr),
+      debugReporter_(std::move(debugReporter)) {
     Ort::SessionOptions sessionOptions;
     sessionOptions.SetIntraOpNumThreads(1);
     auto ortModelPath = Common::onnx::makeOrtPath(modelPath);
 
     try {
+        auto scope = debugReporter_ ? debugReporter_->scope("onnx.create_session", modelPath)
+                                    : Common::debug::ScopedStage{};
         session_ = new Ort::Session(env_, ortModelPath.c_str(), sessionOptions);
     } catch (const Ort::Exception& e) {
         std::cerr << "Error loading rigid registration model: " << e.what() << std::endl;
@@ -59,20 +68,29 @@ RigidRegistrationEngine::~RigidRegistrationEngine() {
 
 std::unordered_map<std::string, std::vector<float>> RigidRegistrationEngine::predict(
     const std::vector<float>& inputTensor, const std::vector<int64_t>& inputShape) {
+    auto scope = debugReporter_ ? debugReporter_->scope("onnx.predict")
+                                : Common::debug::ScopedStage{};
     Ort::AllocatorWithDefaultOptions allocator;
     
     // Prepare input tensor
     auto input_name_allocated = session_->GetInputNameAllocated(0, allocator);
     const char* input_name = input_name_allocated.get();
-    
     std::vector<int64_t> input_shape = inputShape.empty()
                                            ? std::vector<int64_t>{1, 1, 64, 64, 64}
                                            : inputShape;
     Ort::MemoryInfo memory_info =
         Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeDefault);
-    Ort::Value input_tensor = Ort::Value::CreateTensor<float>(
-        memory_info, const_cast<float*>(inputTensor.data()), inputTensor.size(), 
-        input_shape.data(), input_shape.size());
+    Ort::Value input_tensor(nullptr);
+    {
+        auto prepareScope = debugReporter_
+                                ? debugReporter_->scope("onnx.prepare_input_tensor",
+                                                        "elements=" +
+                                                            std::to_string(inputTensor.size()))
+                                : Common::debug::ScopedStage{};
+        input_tensor = Ort::Value::CreateTensor<float>(
+            memory_info, const_cast<float*>(inputTensor.data()), inputTensor.size(),
+            input_shape.data(), input_shape.size());
+    }
     
     // Define output names
     const char* output_names[] = {"ac", "pa", "is"};
@@ -82,25 +100,39 @@ std::unordered_map<std::string, std::vector<float>> RigidRegistrationEngine::pre
     std::vector<Ort::Value> output_tensors;
     std::vector<std::vector<float>> output_buffers(num_outputs,
                                                    std::vector<float>(3));
-    for (size_t i = 0; i < num_outputs; ++i) {
-        Ort::Value output_tensor = Ort::Value::CreateTensor<float>(
-            memory_info, output_buffers[i].data(), output_buffers[i].size(),
-            std::vector<int64_t>{1, 3}.data(), 2);
-        output_tensors.push_back(std::move(output_tensor));
+    {
+        auto prepareScope = debugReporter_
+                                ? debugReporter_->scope("onnx.prepare_output_tensors")
+                                : Common::debug::ScopedStage{};
+        for (size_t i = 0; i < num_outputs; ++i) {
+            std::vector<int64_t> outputShape{1, 3};
+            Ort::Value output_tensor = Ort::Value::CreateTensor<float>(
+                memory_info, output_buffers[i].data(), output_buffers[i].size(),
+                outputShape.data(), outputShape.size());
+            output_tensors.push_back(std::move(output_tensor));
+        }
     }
 
-    session_->Run(Ort::RunOptions{nullptr}, &input_name, &input_tensor, 1,
-                  output_names, output_tensors.data(), 3);
+    {
+        auto inferenceScope = debugReporter_ ? debugReporter_->scope("onnx.run_inference")
+                                             : Common::debug::ScopedStage{};
+        session_->Run(Ort::RunOptions{nullptr}, &input_name, &input_tensor, 1,
+                      output_names, output_tensors.data(), 3);
+    }
 
     std::unordered_map<std::string, std::vector<float>> output;
-    for (size_t i = 0; i < output_tensors.size(); i++) {
-        Ort::TensorTypeAndShapeInfo output_info =
-            output_tensors[i].GetTensorTypeAndShapeInfo();
+    {
+        auto readScope = debugReporter_ ? debugReporter_->scope("onnx.read_outputs")
+                                        : Common::debug::ScopedStage{};
+        for (size_t i = 0; i < output_tensors.size(); i++) {
+            Ort::TensorTypeAndShapeInfo output_info =
+                output_tensors[i].GetTensorTypeAndShapeInfo();
 
-        float* output_data = output_tensors[i].GetTensorMutableData<float>();
-        std::vector<float> output_vector(
-            output_data, output_data + output_info.GetElementCount());
-        output[output_names[i]] = output_vector;
+            float* output_data = output_tensors[i].GetTensorMutableData<float>();
+            std::vector<float> output_vector(
+                output_data, output_data + output_info.GetElementCount());
+            output[output_names[i]] = output_vector;
+        }
     }
 
     return output;

--- a/localizer/src/core/normalizers/RigidRegistrationEngine.h
+++ b/localizer/src/core/normalizers/RigidRegistrationEngine.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "../common/DebugReporter.h"
 #include "../common/ImageTypes.h"
 #include "onnxruntime_cxx_api.h"
 #include <string>
@@ -12,6 +13,8 @@
 class RigidRegistrationEngine {
 public:
     explicit RigidRegistrationEngine(const std::string& modelPath);
+    RigidRegistrationEngine(const std::string& modelPath,
+                            Common::debug::DebugReporterPtr debugReporter);
     ~RigidRegistrationEngine();
     
     /**
@@ -35,4 +38,5 @@ public:
 private:
     Ort::Env env_;
     Ort::Session* session_;
+    Common::debug::DebugReporterPtr debugReporter_;
 };

--- a/localizer/src/core/normalizers/RigidVoxelMorphNormalizer.cpp
+++ b/localizer/src/core/normalizers/RigidVoxelMorphNormalizer.cpp
@@ -1,9 +1,14 @@
 #include "RigidVoxelMorphNormalizer.h"
 
 #include <stdexcept>
+#include <utility>
 
 RigidVoxelMorphNormalizer::RigidVoxelMorphNormalizer(ConfigurationPtr config)
-    : config_(config) {
+    : RigidVoxelMorphNormalizer(config, nullptr) {}
+
+RigidVoxelMorphNormalizer::RigidVoxelMorphNormalizer(
+    ConfigurationPtr config, Common::debug::DebugReporterPtr debugReporter)
+    : config_(config), debugReporter_(std::move(debugReporter)) {
     if (!config_) {
         throw std::invalid_argument("RigidVoxelMorphNormalizer requires configuration");
     }
@@ -68,6 +73,9 @@ void RigidVoxelMorphNormalizer::setDebugMode(bool enable,
                                              const std::string& basePath) {
     debugMode_ = enable;
     debugBasePath_ = basePath;
+    if (enable && !debugReporter_) {
+        debugReporter_ = std::make_shared<Common::debug::DebugReporter>("rigid");
+    }
     if (rigidNormalizer_) {
         rigidNormalizer_->setDebugMode(enable, basePath);
     }
@@ -78,7 +86,10 @@ void RigidVoxelMorphNormalizer::setDebugMode(bool enable,
 
 RigidAlignmentNormalizer& RigidVoxelMorphNormalizer::rigidNormalizer() {
     if (!rigidNormalizer_) {
-        rigidNormalizer_ = std::make_unique<RigidAlignmentNormalizer>(config_);
+        auto scope = debugReporter_ ? debugReporter_->scope("create_rigid_normalizer")
+                                    : Common::debug::ScopedStage{};
+        rigidNormalizer_ =
+            std::make_unique<RigidAlignmentNormalizer>(config_, debugReporter_);
         rigidNormalizer_->setDebugMode(debugMode_, debugBasePath_);
     }
     return *rigidNormalizer_;

--- a/localizer/src/core/normalizers/RigidVoxelMorphNormalizer.h
+++ b/localizer/src/core/normalizers/RigidVoxelMorphNormalizer.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "../common/DebugReporter.h"
 #include "../interfaces/ISpatialNormalizer.h"
 #include "../interfaces/IConfiguration.h"
 #include "RigidAlignmentNormalizer.h"
@@ -11,6 +12,8 @@
 class RigidVoxelMorphNormalizer : public ISpatialNormalizer {
 public:
     explicit RigidVoxelMorphNormalizer(ConfigurationPtr config);
+    RigidVoxelMorphNormalizer(ConfigurationPtr config,
+                              Common::debug::DebugReporterPtr debugReporter);
     virtual ~RigidVoxelMorphNormalizer() = default;
     
     ImageType::Pointer normalize(ImageType::Pointer inputImage) override;
@@ -44,6 +47,7 @@ private:
     // Debug parameters
     bool debugMode_ = false;
     std::string debugBasePath_ = "";
+    Common::debug::DebugReporterPtr debugReporter_;
 
     RigidAlignmentNormalizer& rigidNormalizer();
     VoxelMorphNormalizer& voxelMorphNormalizer();

--- a/localizer/src/core/preprocessing/ImagePreprocessor.cpp
+++ b/localizer/src/core/preprocessing/ImagePreprocessor.cpp
@@ -2,18 +2,43 @@
 #include "itkAffineTransform.h"
 #include <algorithm>
 
-ImageType::Pointer ImagePreprocessor::preprocessForRigid(ImageType::Pointer image) {
+ImageType::Pointer ImagePreprocessor::preprocessForRigid(
+    ImageType::Pointer image,
+    Common::debug::DebugReporter* debugReporter,
+    const std::string& debugLabelPrefix) {
+    auto scope = debugReporter ? debugReporter->scope(debugLabelPrefix)
+                               : Common::debug::ScopedStage{};
     itk::Vector<double, 3> spacing;
     spacing.Fill(3.0);
 
-    image = clipIntensityPercentiles(image, 0.01, 0.99);
-    image = gaussianSmooth(image, 1);
-    image = resampleImage(image, spacing);
-    image = cropForeground(image, 0.35);
+    {
+        auto stage = debugReporter ? debugReporter->scope(debugLabelPrefix + ".clip_intensity")
+                                   : Common::debug::ScopedStage{};
+        image = clipIntensityPercentiles(image, 0.01, 0.99);
+    }
+    {
+        auto stage = debugReporter ? debugReporter->scope(debugLabelPrefix + ".gaussian_smooth")
+                                   : Common::debug::ScopedStage{};
+        image = gaussianSmooth(image, 1);
+    }
+    {
+        auto stage = debugReporter ? debugReporter->scope(debugLabelPrefix + ".resample_3mm")
+                                   : Common::debug::ScopedStage{};
+        image = resampleImage(image, spacing);
+    }
+    {
+        auto stage = debugReporter ? debugReporter->scope(debugLabelPrefix + ".crop_foreground")
+                                   : Common::debug::ScopedStage{};
+        image = cropForeground(image, 0.35);
+    }
 
     itk::Size<3> outputSize;
     outputSize.Fill(64);
-    image = resizeImage(image, outputSize);
+    {
+        auto stage = debugReporter ? debugReporter->scope(debugLabelPrefix + ".resize_64")
+                                   : Common::debug::ScopedStage{};
+        image = resizeImage(image, outputSize);
+    }
     return image;
 }
 
@@ -196,4 +221,3 @@ double ImagePreprocessor::getPercentileValue(std::vector<float>& values,
     std::nth_element(values.begin(), values.begin() + index, values.end());
     return values[index];
 }
-

--- a/localizer/src/core/preprocessing/ImagePreprocessor.h
+++ b/localizer/src/core/preprocessing/ImagePreprocessor.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "../common/DebugReporter.h"
 #include "../common/ImageTypes.h"
 #include "itkDiscreteGaussianImageFilter.h"
 #include "itkIntensityWindowingImageFilter.h"
@@ -7,6 +8,7 @@
 #include "itkRegionOfInterestImageFilter.h"
 #include "itkConstantBoundaryCondition.h"
 #include "itkLinearInterpolateImageFunction.h"
+#include <string>
 #include <vector>
 
 /**
@@ -20,7 +22,10 @@ public:
     /**
      * @brief Preprocess image for rigid registration
      */
-    static ImageType::Pointer preprocessForRigid(ImageType::Pointer image);
+    static ImageType::Pointer preprocessForRigid(
+        ImageType::Pointer image,
+        Common::debug::DebugReporter* debugReporter = nullptr,
+        const std::string& debugLabelPrefix = "rigid.preprocess");
     
     /**
      * @brief Preprocess image for VoxelMorph registration
@@ -43,4 +48,3 @@ private:
     static std::vector<float> getPixelValues(ImageType::Pointer image);
     static double getPercentileValue(std::vector<float>& values, double percentile);
 };
-

--- a/localizer/src/core/services/SpatialNormalizationService.cpp
+++ b/localizer/src/core/services/SpatialNormalizationService.cpp
@@ -1,4 +1,5 @@
 #include "SpatialNormalizationService.h"
+#include "../common/DebugReporter.h"
 #include "../common/NiftiIO.h"
 #include "../common/ImageOps.h"
 #include "../normalizers/RigidVoxelMorphNormalizer.h"
@@ -17,18 +18,26 @@ SpatialNormalizationService::SpatialNormalizationService(ConfigurationPtr config
 
 SpatialNormalizationOutput SpatialNormalizationService::normalize(const SpatialNormalizationRequest& request) {
     SpatialNormalizationOutput output;
-    ImageType::Pointer inputImage = loadInput(request.inputPath);
+    const auto& debugReporter = request.options.debugReporter;
+    ImageType::Pointer inputImage;
+    {
+        auto scope = debugReporter ? debugReporter->scope("load_input", request.inputPath)
+                                   : Common::debug::ScopedStage{};
+        inputImage = loadInput(request.inputPath);
+    }
 
     if (request.skip) {
         output.rigidAlignedImage = inputImage;
         output.spatiallyNormalizedImage = inputImage;
     } else {
-        auto normalizer = std::make_shared<RigidVoxelMorphNormalizer>(config_);
+        auto normalizer = std::make_shared<RigidVoxelMorphNormalizer>(config_, debugReporter);
         if (request.options.enableDebugOutput) {
             normalizer->setDebugMode(true, request.options.debugOutputBasePath);
         }
 
         if (request.options.rigidOnly) {
+            auto scope = debugReporter ? debugReporter->scope("normalize.rigid_only")
+                                       : Common::debug::ScopedStage{};
             output.rigidAlignedImage = request.options.useIterativeRigid
                                            ? normalizer->normalizeIterativeRigidOnly(
                                                  inputImage,

--- a/localizer/src/spatialNormalizations/rigid/RigidCLI.cpp
+++ b/localizer/src/spatialNormalizations/rigid/RigidCLI.cpp
@@ -1,5 +1,6 @@
 #include "RigidCLI.h"
 #include "../CLIOptions.h"
+#include "../../core/common/DebugReporter.h"
 #include "../../core/common/Filesystem.h"
 #include "../../core/common/PathUtils.h"
 #include "../../core/config/Version.h"
@@ -32,13 +33,29 @@ int processSingleImage(const NormalizeCommandOptions& options,
                        const std::string& inputPath,
                        const std::string& outputPath,
                        const std::string& debugOutputBasePath,
+                       const std::string& fullCommand,
                        bool logCompletion) {
+    Common::debug::DebugReporterPtr debugReporter;
+    if (options.enableDebugOutput) {
+        debugReporter = std::make_shared<Common::debug::DebugReporter>("rigid");
+        debugReporter->event("command_start",
+                             "input=" + inputPath +
+                                 " output=" + outputPath +
+                                 " iterative=" +
+                                 (options.useIterativeRigid ? "true" : "false"));
+        debugReporter->event("command_line", fullCommand);
+    }
+
     BootstrapOptions bootstrapOptions;
     bootstrapOptions.configPath = options.configPath;
     bootstrapOptions.enableConfigDebug = options.enableDebugOutput;
     bootstrapOptions.logTag = "rigid";
 
-    auto container = Pipeline::buildCoreContainer(bootstrapOptions);
+    std::shared_ptr<Pipeline::ServiceContainer> container;
+    {
+        auto scope = debugReporter ? debugReporter->scope("bootstrap") : Common::debug::ScopedStage{};
+        container = Pipeline::buildCoreContainer(bootstrapOptions);
+    }
     auto spatialService = container->resolve<ISpatialNormalizationService>();
     auto fileService = container->resolve<IFileService>();
 
@@ -49,10 +66,19 @@ int processSingleImage(const NormalizeCommandOptions& options,
     request.options.useIterativeRigid = options.useIterativeRigid;
     request.options.enableDebugOutput = options.enableDebugOutput;
     request.options.debugOutputBasePath = debugOutputBasePath;
+    request.options.debugReporter = debugReporter;
 
     try {
-        auto output = spatialService->normalize(request);
-        fileService->saveNormalizedImage({output.spatiallyNormalizedImage, outputPath});
+        SpatialNormalizationOutput output;
+        {
+            auto scope = debugReporter ? debugReporter->scope("normalize") : Common::debug::ScopedStage{};
+            output = spatialService->normalize(request);
+        }
+        {
+            auto scope = debugReporter ? debugReporter->scope("save_output", outputPath)
+                                       : Common::debug::ScopedStage{};
+            fileService->saveNormalizedImage({output.spatiallyNormalizedImage, outputPath});
+        }
         if (logCompletion) {
             std::cout << "[rigid] Rigid alignment complete. Output saved to "
                       << outputPath << std::endl;
@@ -78,6 +104,7 @@ int runSingleRigid(const NormalizeCommandOptions& options, const std::string& fu
         options.inputPath,
         options.outputPath,
         options.debugOutputBasePath,
+        fullCommand,
         true);
 }
 
@@ -131,7 +158,8 @@ int runBatchRigid(const NormalizeCommandOptions& options, const std::string& ful
         const std::string debugBase = resolveDebugBasePath(options, outputPath);
 
         try {
-            const int result = processSingleImage(options, inputPath, outputPath, debugBase, false);
+            const int result =
+                processSingleImage(options, inputPath, outputPath, debugBase, fullCommand, false);
             if (result != EXIT_SUCCESS) {
                 throw std::runtime_error("Rigid alignment failed.");
             }

--- a/python/dcccpy-linux-arm64-runtime/README.md
+++ b/python/dcccpy-linux-arm64-runtime/README.md
@@ -7,7 +7,7 @@ including NVIDIA DGX Spark.
 Before building this package, vendor the release asset:
 
 ```bash
-python scripts/vendor_dccccore.py --version 4.2.3 --release-platform ubuntu-latest-arm64
+python scripts/vendor_dccccore.py --version 4.2.4 --release-platform ubuntu-latest-arm64
 python -m build --wheel
 ```
 

--- a/python/dcccpy-linux-arm64-runtime/scripts/vendor_dccccore.py
+++ b/python/dcccpy-linux-arm64-runtime/scripts/vendor_dccccore.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 
 REPO = "tctco/DCCCSlicer"
-DEFAULT_VERSION = "4.2.3"
+DEFAULT_VERSION = "4.2.4"
 DEFAULT_RELEASE_PLATFORM = "ubuntu-latest-arm64"
 
 EXCLUDE_PROFILES = {

--- a/python/dcccpy/README.md
+++ b/python/dcccpy/README.md
@@ -142,7 +142,7 @@ the calculation again.
 Release wheels should vendor the matching `DCCCcore` runtime tree before build:
 
 ```bash
-python scripts/vendor_dccccore.py --version 4.2.3 --release-platform ubuntu-latest-x64
+python scripts/vendor_dccccore.py --version 4.2.4 --release-platform ubuntu-latest-x64
 python -m build --wheel
 ```
 
@@ -150,7 +150,7 @@ The Linux ARM64 runtime package uses the corresponding release asset:
 
 ```bash
 cd python/dcccpy-linux-arm64-runtime
-python scripts/vendor_dccccore.py --version 4.2.3 --release-platform ubuntu-latest-arm64
+python scripts/vendor_dccccore.py --version 4.2.4 --release-platform ubuntu-latest-arm64
 python -m build --wheel
 ```
 

--- a/python/dcccpy/scripts/vendor_dccccore.py
+++ b/python/dcccpy/scripts/vendor_dccccore.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 
 REPO = "tctco/DCCCSlicer"
-DEFAULT_VERSION = "4.2.3"
+DEFAULT_VERSION = "4.2.4"
 DEFAULT_RELEASE_PLATFORM = "ubuntu-latest-x64"
 DEFAULT_VENDOR_PLATFORM = "linux-x86_64"
 

--- a/python/dcccpy/src/dcccpy/runtime.py
+++ b/python/dcccpy/src/dcccpy/runtime.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Iterable
 
 
-DCCCCORE_VERSION = "4.2.3"
+DCCCCORE_VERSION = "4.2.4"
 RELEASE_REPO = "tctco/DCCCSlicer"
 
 

--- a/python/dcccpy/tests/test_core.py
+++ b/python/dcccpy/tests/test_core.py
@@ -135,7 +135,7 @@ def test_dccccore_path_can_disable_auto_download(tmp_path: Path, monkeypatch: py
 
 
 def test_dccccore_path_auto_downloads_to_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    asset_root = tmp_path / "asset" / "DCCCcore-4.2.3-ubuntu-latest-x64"
+    asset_root = tmp_path / "asset" / "DCCCcore-4.2.4-ubuntu-latest-x64"
     asset_root.mkdir(parents=True)
     exe = asset_root / "DCCCcore"
     exe.write_text("#!/usr/bin/env sh\nprintf 'fake dccccore\\n'\n")
@@ -143,7 +143,7 @@ def test_dccccore_path_auto_downloads_to_cache(tmp_path: Path, monkeypatch: pyte
 
     archive = tmp_path / "DCCCcore.zip"
     with zipfile.ZipFile(archive, "w") as zf:
-        zf.write(exe, "DCCCcore-4.2.3-ubuntu-latest-x64/DCCCcore")
+        zf.write(exe, "DCCCcore-4.2.4-ubuntu-latest-x64/DCCCcore")
 
     monkeypatch.delenv("DCCCPY_DCCCCORE", raising=False)
     monkeypatch.setenv("DCCCPY_AUTO_DOWNLOAD", "1")


### PR DESCRIPTION
## Summary

- add an RAII `DebugReporter` for structured stage timings
- instrument rigid loading, preprocessing, ONNX inference, iterative convergence, debug image output, and final save
- document large CTA `.nii.gz` compression as a separate benchmark cost
- release DCCCcore 4.2.4 without the previous `-alpha` suffix
- point dcccpy and the Linux ARM64 vendor helper at the 4.2.4 GitHub release

## Behavior

The registration algorithm and default non-debug path are unchanged. Timing output is enabled only when the rigid command receives `--debug`. The ONNX output tensor setup also replaces a temporary shape-vector pointer with a named local shape whose lifetime covers tensor creation.

## Validation

- clean-first Docker build: all 60 DCCCcore C++ objects compiled and linked
- rebuilt binary reports `4.2.4`
- maximum referenced glibc version: `2.16`
- real 8 MB PET NIfTI completed `rigid --iterative --debug`, converged after two iterative passes, and produced a valid output NIfTI
- dcccpy tests: `11 passed, 1 skipped`
- UI metric command tests: `4 passed`
- `git diff --check` passed