### PR TITLE
Fix Linux ARM64 legacy CMake resolution

### DIFF
--- a/docker/Dockerfile.core.legacy
+++ b/docker/Dockerfile.core.legacy
@@ -37,11 +37,13 @@ RUN perl -MIPC::Cmd -MTime::Piece -e 1 \
     && autoreconf --version
 
 RUN python -m pip install --no-cache-dir --default-timeout=120 --retries=10 \
-      "cmake>=3.27,<4" \
+      "cmake==3.31.10" \
       "conan>=2.0,<3" \
       ninja \
       pandas \
-      pytest
+      pytest \
+    && cmake --version \
+    && cmake -E capabilities >/dev/null
 
 RUN groupadd --gid ${USER_GID} ${USERNAME} \
     && useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME} -s /bin/bash \

--- a/docker/conan/legacy-system-tools
+++ b/docker/conan/legacy-system-tools
@@ -1,0 +1,10 @@
+include(default)
+
+# Conan Center recipes request several CMake versions as transitive build
+# requirements. Use the manylinux2014-compatible CMake already installed in
+# the container instead of upstream binaries that require a newer glibc.
+[replace_tool_requires]
+cmake/*: cmake/3.31.10
+
+[platform_tool_requires]
+cmake/3.31.10

--- a/localizer/lib/macos_security.py
+++ b/localizer/lib/macos_security.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 import shlex
 import sys
-from pathlib import Path
 
 
 _SECURITY_MARKERS = (
@@ -27,8 +26,8 @@ def is_macos() -> bool:
 
 
 def macos_security_hint(executable_path: str | os.PathLike[str]) -> str:
-    path = Path(executable_path).expanduser()
-    quoted_path = shlex.quote(os.fspath(path))
+    path = os.path.expanduser(os.fspath(executable_path))
+    quoted_path = shlex.quote(path)
     return (
         "macOS may have blocked DCCCcore because it was downloaded from the internet.\n"
         "Open System Settings > Privacy & Security and allow DCCCcore, or run this "

--- a/scripts/docker-build-core.sh
+++ b/scripts/docker-build-core.sh
@@ -7,6 +7,7 @@ BUILD_TYPE="${BUILD_TYPE:-Release}"
 INSTALL_PREFIX="${INSTALL_PREFIX:-./install}"
 CONAN_CPPSTD="${CONAN_CPPSTD:-gnu17}"
 CONAN_BUILD_ARGS="${CONAN_BUILD_ARGS:---build=missing}"
+CONAN_PROFILE="${CONAN_PROFILE:-/workspace/docker/conan/legacy-system-tools}"
 # Split the simple, space-delimited Conan build policy string into argv items.
 # This lets the legacy Linux path force known build tools such as b2 to be
 # rebuilt inside the manylinux2014 container instead of downloading binaries
@@ -19,6 +20,7 @@ sudo chown -R "$(id -u):$(id -g)" build "${CONAN_HOME:-/home/dev/.conan2}"
 conan profile detect --force
 conan install . \
   --output-folder=build \
+  --profile:all="${CONAN_PROFILE}" \
   "${conan_build_args[@]}" \
   -s build_type="${BUILD_TYPE}" \
   -s compiler.cppstd="${CONAN_CPPSTD}" \


### PR DESCRIPTION
## Summary

- pin the manylinux2014 container CMake to 3.31.10
- replace transitive Conan `cmake/*` tool requirements with that platform-provided executable
- make the legacy build script apply the dedicated Conan profile in both host and build contexts

## Root cause

The `v4.2.4` ARM64 release job downloaded Conan CMake 3.31.12 and 4.4.0 ARM64 binaries. Those executables require GLIBC 2.25/2.28 and cannot run in the manylinux2014 GLIBC 2.17 container, causing the `expat` build to fail.

## Validation

- `bash -n scripts/docker-build-core.sh`
- `git diff --check`
- manylinux2014 container reports CMake 3.31.10
- fresh Conan dependency graph resolves all five transitive CMake ranges to `cmake/3.31.10#platform` and downloads no Conan CMake binary

Failed release run: https://github.com/tctco/DCCCSlicer/actions/runs/29936695109