### PR TITLE
Fix ADAD command and release 4.2.6

### DIFF
--- a/localizer/lib/ai_decoupling.py
+++ b/localizer/lib/ai_decoupling.py
@@ -62,16 +62,16 @@ class AIDecouplingLogic:
             tmp_path = str(self.plugin_path / "tmp.nii")
             slicer.util.saveNode(input_node, tmp_path)
             
-            # Build command using new subcommand format
+            # Build command using the current ADAD subcommand.
             cmd = [
                 str(self.executable_path),
-                "decouple",
+                "adad",
                 "--input", tmp_path,
                 "--output", str(self.plugin_path / "Normalized.nii"),
                 "--modality", normalized_modality
             ]
                 
-            print(f"Running decouple command: {' '.join(cmd)}")
+            print(f"Running ADAD command: {' '.join(cmd)}")
             try:
                 result = subprocess.run(cmd, capture_output=True, text=True, cwd=self.plugin_path)
             except Exception as e:

--- a/localizer/src/CMakeLists.txt
+++ b/localizer/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 # CMakeList.txt: DCCCcore Refactored Version
 cmake_minimum_required(VERSION 3.21)
 
-project(DCCCcore VERSION 4.2.5)
+project(DCCCcore VERSION 4.2.6)
 set(DCCCCORE_VERSION_SUFFIX "")
 set(DCCCCORE_SOFTWARE_VERSION "${PROJECT_VERSION}${DCCCCORE_VERSION_SUFFIX}")
 

--- a/localizer/src/conanfile.py
+++ b/localizer/src/conanfile.py
@@ -4,7 +4,7 @@ from conan import ConanFile
 
 class AppConan(ConanFile):
     name = "DCCCcore"
-    version = "4.2.5"
+    version = "4.2.6"
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain"
 

--- a/localizer/src/core/config/Version.h
+++ b/localizer/src/core/config/Version.h
@@ -1,4 +1,4 @@
 #pragma once
 #include <string>
 
-const std::string SOFTWARE_VERSION = "4.2.5";
+const std::string SOFTWARE_VERSION = "4.2.6";

--- a/localizer/src/tests/test_ui_ai_decoupling.py
+++ b/localizer/src/tests/test_ui_ai_decoupling.py
@@ -1,0 +1,47 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+
+def _load_ai_decoupling_logic():
+    if "slicer" not in sys.modules:
+        sys.modules["slicer"] = types.SimpleNamespace(
+            util=types.SimpleNamespace(saveNode=lambda *_args: True)
+        )
+    else:
+        slicer_module = sys.modules["slicer"]
+        if not hasattr(slicer_module, "util"):
+            slicer_module.util = types.SimpleNamespace()
+        slicer_module.util.saveNode = lambda *_args: True
+
+    repo_root = Path(__file__).resolve().parents[3]
+    sys.path.insert(0, str(repo_root / "localizer" / "lib"))
+    module = importlib.import_module("ai_decoupling")
+    return module, module.AIDecouplingLogic
+
+
+def test_decouple_image_uses_adad_subcommand(monkeypatch):
+    module, logic_type = _load_ai_decoupling_logic()
+    logic = logic_type("/tmp/plugin")
+    captured = {}
+
+    def fake_run(command, **kwargs):
+        captured["command"] = command
+        captured["kwargs"] = kwargs
+        return types.SimpleNamespace(returncode=0, stdout="ADAD score: 1", stderr="")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        logic,
+        "_load_result_volumes",
+        lambda: (object(), object(), object()),
+    )
+
+    input_node = types.SimpleNamespace(GetName=lambda: "PET")
+    success, *_ = logic.decouple_image(input_node, "Abeta")
+
+    assert success
+    assert captured["command"][:2] == [str(logic.executable_path), "adad"]
+    assert captured["command"][-2:] == ["--modality", "abeta"]
+    assert captured["kwargs"]["cwd"] == Path("/tmp/plugin")


### PR DESCRIPTION
## What changed

- update the Slicer AI decoupling launcher to call the registered `adad` subcommand instead of the removed `decouple` command
- add a regression test covering the generated ADAD invocation
- bump the core release version from 4.2.5 to 4.2.6 in CMake, Conan, and the committed generated version header

## Root cause

The core CLI renamed the decoupling entry point to `adad`, but the Slicer frontend continued invoking `decouple`. Argparse therefore rejected the command before processing the image.

## User impact

Abeta and Tau signal decoupling can launch successfully from Slicer with DCCCcore 4.2.6.

## Validation

- `UV_CACHE_DIR=/tmp/dcccslicer-uv-cache uv run --with pytest pytest localizer/src/tests/test_ui_ai_decoupling.py localizer/src/tests/test_ui_metric_command_builder.py -q` (`7 passed`)
- audited all other frontend and Python-wrapper subcommand names against the currently registered DCCCcore command catalog
- `git diff --check`